### PR TITLE
Add direct-run fallback and navigation logging

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2,10 +2,16 @@
 import asyncio
 from datetime import datetime, timedelta
 from urllib.parse import quote
+
 from apify import Actor
 from crawlee import Request
 from crawlee.crawlers import PlaywrightCrawler, PlaywrightCrawlingContext
-from .routes import router
+
+try:
+    # Allow running both as a package (Apify entrypoint) and as a script for local debugging
+    from .routes import router  # type: ignore
+except ImportError:  # pragma: no cover - fallback for direct execution
+    from routes import router
 
 CITY_MAP = {
     "goa": "CTGOI", "mumbai": "CTBOM", "delhi": "CTDEL",
@@ -16,7 +22,8 @@ CITY_MAP = {
 def format_date(date_str, fmt):
     try:
         return datetime.strptime(date_str, "%Y-%m-%d").strftime(fmt)
-    except: return date_str
+    except Exception:
+        return date_str
 
 def build_booking_url(dest, ci, co):
     return f"https://www.booking.com/searchresults.html?ss={quote(dest)}&checkin={ci}&checkout={co}&group_adults=2&no_rooms=1"
@@ -56,55 +63,66 @@ def build_cleartrip_url(dest, ci, co):
 async def main() -> None:
     async with Actor:
         actor_input = await Actor.get_input() or {}
-        
+
         destination = actor_input.get("destination", "Goa")
         check_in = actor_input.get("checkInDate", "2025-12-01")
         check_out = actor_input.get("checkOutDate", "2025-12-05")
         proxy_config = actor_input.get("proxyConfiguration", {})
-        
+
         if proxy_config and proxy_config.get("useApifyProxy"):
             proxy_configuration = await Actor.create_proxy_configuration(
                 groups=proxy_config.get("apifyProxyGroups", ["RESIDENTIAL"]),
-                country_code="IN" 
+                country_code="IN",
             )
         else:
             proxy_configuration = None
 
-        # --- FIX: PACKING DATA FOR ROUTES ---
         user_context = {
             "destination": destination,
             "checkIn": check_in,
-            "checkOut": check_out
+            "checkOut": check_out,
         }
 
         start_requests = [
             Request.from_url(build_booking_url(destination, check_in, check_out), label="BOOKING", user_data=user_context),
             Request.from_url(build_yatra_url(destination, check_in, check_out), label="YATRA", user_data=user_context),
             Request.from_url(build_mmt_url(destination, check_in, check_out), label="MMT", user_data=user_context),
-            Request.from_url(build_cleartrip_url(destination, check_in, check_out), label="CLEARTRIP", user_data=user_context)
+            Request.from_url(build_cleartrip_url(destination, check_in, check_out), label="CLEARTRIP", user_data=user_context),
         ]
-        
+
         crawler = PlaywrightCrawler(
             request_handler=router,
             proxy_configuration=proxy_configuration,
             headless=True,
             request_handler_timeout=timedelta(minutes=6),
+            max_request_retries=1,
+            max_requests_per_crawl=len(start_requests),
             browser_launch_options={
-                "args": ["--disable-http2", "--disable-blink-features=AutomationControlled", "--disable-infobars", "--no-sandbox"],
-                "ignore_https_errors": True
-            }
+                "args": [
+                    "--disable-http2",
+                    "--disable-blink-features=AutomationControlled",
+                    "--disable-infobars",
+                    "--no-sandbox",
+                ],
+                "ignore_https_errors": True,
+            },
         )
 
         @crawler.pre_navigation_hook
         async def configure_browser(context: PlaywrightCrawlingContext) -> None:
-            await context.page.add_init_script("Object.defineProperty(navigator, 'webdriver', {get: () => undefined})")
+            await context.page.add_init_script(
+                "Object.defineProperty(navigator, 'webdriver', {get: () => undefined})"
+            )
             context.page.set_default_navigation_timeout(90000)
             context.page.set_default_timeout(60000)
-            await context.page.set_extra_http_headers({
-                "Accept-Language": "en-US,en;q=0.9",
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
-                "Referer": "https://www.google.com/"
-            })
+            await context.page.set_extra_http_headers(
+                {
+                    "Accept-Language": "en-US,en;q=0.9",
+                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+                    "Referer": "https://www.google.com/",
+                }
+            )
+            context.log.info(f"Navigating {context.request.label} :: {context.request.url}")
 
         await crawler.run(start_requests)
 

--- a/src/main.py
+++ b/src/main.py
@@ -36,9 +36,8 @@ def build_yatra_url(dest, ci, co):
     return (
         f"https://hotel.yatra.com/nextui/hotel-search/dom/search?"
         f"checkinDate={quote(c_in)}&checkoutDate={quote(c_out)}&"
-        f"source=BOOKING_ENGINE&pg=1&tenant=PWA&isPersnldSrp=1&"
-        f"city.name={d}&city.code={d}&state.name={d}&state.code={d}&"
-        f"country.name=India&country.code=IND&"
+        f"source=BOOKING_ENGINE&pg=1&tenant=PWA&"
+        f"city.name={d}&city.code={d}&country.name=India&country.code=IND&"
         f"roomRequests%5B0%5D.id=1&roomRequests%5B0%5D.noOfAdults=2&roomRequests%5B0%5D.noOfChildren=0"
     )
 

--- a/src/routes.py
+++ b/src/routes.py
@@ -169,20 +169,22 @@ async def handle_mmt(context: PlaywrightCrawlingContext) -> None:
         # Makemytrip sometimes renders into #hotelListingContainer first; fall back to
         # the older id-based cards. Waiting for either prevents the handler from timing out.
         try:
-            await page.wait_for_selector('#hotelListingContainer, [id^="htl_id"]', timeout=20000)
+            await page.wait_for_selector('#hotelListingContainer, [id^="htl_id"], .listingRowOuter', timeout=30000)
         except:  # pragma: no cover - best effort
             pass
 
+        # Prime the page by scrolling; cards load lazily.
         await page.mouse.wheel(0, 4000)
-        
+        await page.wait_for_timeout(1500)
+
         # Standard Selectors
-        cards = await page.locator('[id^="htl_id"], .listingRow').all()
-        
+        cards = await page.locator('[id^="htl_id"], .listingRowOuter, .listingRow').all()
+
         # Fallback to Text Anchors if empty
         if len(cards) == 0:
             price_els = await page.locator('text=/₹/').all()
-            # MMT nesting is deep, usually 4-5 divs up
-            cards = [p.locator('xpath=./ancestor::div[5]') for p in price_els]
+            # MMT nesting is deep, usually 4-6 divs up
+            cards = [p.locator('xpath=./ancestor::div[6]') for p in price_els]
 
         for card in cards[:25]:
             item = {"source": "MakeMyTrip", "destination": data.get('destination'), "check_in": data.get('checkIn'), "check_out": data.get('checkOut')}
@@ -199,6 +201,8 @@ async def handle_mmt(context: PlaywrightCrawlingContext) -> None:
                 price = "0"
                 if await card.locator('text=/₹/').count() > 0:
                     price = await card.locator('text=/₹/').first.inner_text(timeout=1000)
+                elif await card.locator('[class*="price" i]').count() > 0:
+                    price = await card.locator('[class*="price" i]').first.inner_text(timeout=1000)
 
                 item["hotel_name"] = clean_text(name)
                 item["price_numeric"] = extract_price(price)
@@ -224,27 +228,39 @@ async def handle_cleartrip(context: PlaywrightCrawlingContext) -> None:
     try:
         await page.wait_for_load_state("domcontentloaded")
         if "Access Denied" in await page.content(): return
-        
-        # Cleartrip Price Anchor Strategy (Most robust for this site)
-        price_els = await page.locator('text=/₹|Rs/').all()
-        
-        for p in price_els:
+
+        # Prefer structured cards; fall back to price anchors if the layout differs.
+        cards = await page.locator('[data-testid="ResultCard"], [data-testid="hotelCard"], article, [class*="HotelCard" i]').all()
+
+        # If no cards resolved, use price anchors and walk up the tree to locate a container.
+        if len(cards) == 0:
+            price_els = await page.locator('text=/₹|Rs/').all()
+            cards = [p.locator('xpath=./ancestor::div[4]') for p in price_els]
+
+        for card in cards:
             item = {"source": "Cleartrip", "destination": data.get('destination'), "check_in": data.get('checkIn'), "check_out": data.get('checkOut')}
             try:
-                # Go up 3 levels to find Card
-                card = p.locator('xpath=./ancestor::div[3]')
-                
-                # Visual Text Analysis for Name
-                name = await find_best_name(card)
-                price = await p.inner_text(timeout=1000)
+                # Name candidates (ordered preference)
+                name_locator = card.locator('[data-testid="hotelName"], [itemprop="name"], h3, h2, a')
+                name = None
+                if await name_locator.count() > 0:
+                    name = await name_locator.first.inner_text(timeout=1000)
+                if not name:
+                    name = await find_best_name(card)
 
-                item["hotel_name"] = name
+                # Price candidates
+                price_locator = card.locator('text=/₹|Rs/, [class*="price" i]')
+                price = None
+                if await price_locator.count() > 0:
+                    price = await price_locator.first.inner_text(timeout=1000)
+
+                item["hotel_name"] = clean_text(name)
                 item["price_numeric"] = extract_price(price)
-                item["price_display"] = price
+                item["price_display"] = price or "N/A"
                 item["hotel_img"] = await extract_image(card)
                 item["rating"] = await extract_rating(card)
                 item["amenities"] = await extract_amenities(card)
-                
+
                 if item.get("hotel_name") and item.get("price_numeric") and item["hotel_name"] not in seen:
                     results.append(item)
                     seen.add(item["hotel_name"])

--- a/src/routes.py
+++ b/src/routes.py
@@ -165,8 +165,14 @@ async def handle_mmt(context: PlaywrightCrawlingContext) -> None:
     seen = set()
     try:
         if "Access Denied" in await page.content(): return
-        try: await page.wait_for_selector('[id^="htl_id"]', timeout=15000)
-        except: pass
+
+        # Makemytrip sometimes renders into #hotelListingContainer first; fall back to
+        # the older id-based cards. Waiting for either prevents the handler from timing out.
+        try:
+            await page.wait_for_selector('#hotelListingContainer, [id^="htl_id"]', timeout=20000)
+        except:  # pragma: no cover - best effort
+            pass
+
         await page.mouse.wheel(0, 4000)
         
         # Standard Selectors


### PR DESCRIPTION
## Summary
- allow the crawler to import routing both as a package and when run directly for debugging
- tighten crawler configuration to retry less, cap crawl count, and log each navigation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fe5418fa883248a33dc6fe1ac16e9)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add direct-run fallback and navigation logging to improve crawler functionality and configuration.
> 
>   - **Behavior**:
>     - Add fallback in `main.py` to import `router` from `routes` for direct execution.
>     - Log each navigation event in `main.py` using `context.log.info()`.
>     - Update crawler configuration in `main.py` to retry once and cap crawl count to the number of start requests.
>   - **Handlers**:
>     - Update `handle_mmt()` in `routes.py` to handle both `#hotelListingContainer` and id-based cards.
>     - Update `handle_cleartrip()` in `routes.py` to prefer structured cards and fall back to price anchors.
>   - **Misc**:
>     - Minor formatting changes in `main.py` and `routes.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=xoashh%2Fhotelscraper&utm_source=github&utm_medium=referral)<sup> for 02f81dbb8a4b788aa36f6e08f6d8412ca1c4c754. You can [customize](https://app.ellipsis.dev/xoashh/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->